### PR TITLE
Version 0.3 + Doc fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raur-ext"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["morganamilo <morganamilo@gmail.com>"]
 edition = "2018"
 
@@ -12,4 +12,4 @@ license = "GPL-3.0"
 keywords = ["archlinux", "pkgbuild", "arch", "aur", "raur"]
 
 [dependencies]
-raur = "1.0.2"
+raur = "2.0.0"

--- a/src/raur.rs
+++ b/src/raur.rs
@@ -1,7 +1,7 @@
 use crate::Cache;
-use raur::{Error, Handle, Package};
+use raur::{Error, Handle, Package, Raur};
 
-/// Extension functions to raur::Package
+/// Extension functions to raur::Handle
 pub trait RaurExt {
     /// Perform an info request, storing the results into cache. Requests are not made
     /// for packages already in cache. If all packages are already in cache then this


### PR DESCRIPTION
Also that little doc fix, and I updated the raur dependency so that this depends on a version where clone is implemented on Package. I'm not sure if the API makes much sense in the context of those other breaking changes, but this seems to work.

If you'd be willing to release this one, I'm in the process of pushing out a release of aurum and it needs to use deps on crates.io. :/